### PR TITLE
network 모듈 백엔드 설정 추가

### DIFF
--- a/modules/network/backend.tf
+++ b/modules/network/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    bucket       = "team-tfstate-bucket"
+    key          = "module/network/terraform.tfstate"
+    region       = "ap-northeast-2"
+    use_lockfile = true # lock 파일 저장
+    encrypt      = true # 암호화 저장
+    profile      = "process"
+  }
+}


### PR DESCRIPTION
> 해당 PR에 다음과 같은 기능을 추가했습니다.

루트 모듈의 s3 백엔드 설정 적용 후,  서브 모듈을 호출하여 실행하면 다른 사람의 작업물이 삭제되는 현상을 발견했습니다.
따라서 각 서브 모듈에 별도의 백엔드 설정을 추가하여 독립적으로 실행할 수 있도록 했습니다.