### PR TITLE
VPC, Subnet 네트워크 대역 수정

### DIFF
--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,4 +1,4 @@
-# 1. VPC 생성 - 10.5.0.0/16
+# 1. VPC 생성 - 20.0.0.0/16
 resource "aws_vpc" "team_VPC" {
   cidr_block           = var.team_vpc_cidr
   enable_dns_hostnames = true # DNS 호스트이름 활성화
@@ -19,9 +19,9 @@ resource "aws_internet_gateway" "team_IGW" {
 
 # 3. Public Subnet 3개 생성
 # * cidr block 정보
-# - 10.5.5.0/24
-# - 10.5.6.0/24
-# - 10.5.7.0/24
+# - 20.0.1.0/24
+# - 20.0.2.0/24
+# - 20.0.3.0/24
 
 resource "aws_subnet" "team_PubSN" {
   count = length(var.team_public_subnets)
@@ -93,9 +93,9 @@ resource "aws_nat_gateway" "team_NAT-GW" {
 
 # 6. Private Subnet 3개 생성
 # * cidr block 정보
-# - 10.5.8.0/24
-# - 10.6.9.0/24
-# - 10.7.1-.0/24
+# - 20.0.4.0/24
+# - 20.0.5.0/24
+# - 20.0.6.0/24
 
 resource "aws_subnet" "team_PriSN" {
   count = length(var.team_private_subnets) # Private Subnet 개수만큼 생성

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,6 +1,6 @@
 variable "team_vpc_cidr" {
   type    = string
-  default = "10.5.0.0/16"
+  default = "20.0.0.0/16"
 }
 
 variable "team_azs" {
@@ -10,12 +10,12 @@ variable "team_azs" {
 
 variable "team_public_subnets" {
   type    = list(string)
-  default = ["10.5.5.0/24", "10.5.6.0/24", "10.5.7.0/24"]
+  default = ["20.0.1.0/24", "20.0.2.0/24", "20.0.3.0/24"]
 }
 
 variable "team_private_subnets" {
   type    = list(string)
-  default = ["10.5.8.0/24", "10.5.9.0/24", "10.5.10.0/24"]
+  default = ["20.0.4.0/24", "20.0.5.0/24", "20.0.6.0/24"]
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
> 해당 PR에 다음과 같은 오류를 수정했습니다.
Site-to-Site VPN을 구성하기 위해서 온프레미스와 클라우드 네트워크 대역이 달라야합니다.
따라서 다음과 같이 VPC, Subnet 네트워크 대역을 수정했습니다.

- VPC : 20.0.0.0/16
- Public Subnet1 : 20.0.1.0/24
- Public Subnet2 : 20.0.2.0/24
- Public Subnet3 : 20.0.3.0/24
- Private Subnet1 : 20.0.4.0/24
- Private Subnet1 : 20.0.5.0/24
- Private Subnet1 : 20.0.6.0/24